### PR TITLE
bump dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,25 +12,25 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "~1.0.1",
-    "purescript-eff": "~1.0.0",
-    "purescript-argonaut-core": "~1.0.0",
-    "purescript-argonaut-codecs": "~1.0.0",
-    "purescript-maybe": "~1.0.0",
-    "purescript-monoid": "~1.0.0",
-    "purescript-tuples": "~1.0.0",
-    "purescript-arrays": "~1.0.0",
-    "purescript-strings": "~1.0.0",
-    "purescript-sets": "~1.0.0",
-    "purescript-foldable-traversable": "~1.0.0",
-    "purescript-either": "~1.0.0",
-    "purescript-ansi": "~1.0.0",
-    "purescript-node-path": "~1.0.0",
-    "purescript-control": "~1.0.0",
-    "purescript-console": "~1.0.0",
-    "purescript-unsafe-coerce": "~1.0.0"
+    "purescript-prelude": "^1.0.1",
+    "purescript-eff": "^1.0.0",
+    "purescript-argonaut-core": "^1.0.0",
+    "purescript-argonaut-codecs": "^1.0.0",
+    "purescript-maybe": "^1.0.0",
+    "purescript-monoid": "^1.0.0",
+    "purescript-tuples": "^1.0.0",
+    "purescript-arrays": "^1.0.0",
+    "purescript-strings": "^1.0.0",
+    "purescript-sets": "^1.0.0",
+    "purescript-foldable-traversable": "^1.0.0",
+    "purescript-either": "^1.0.0",
+    "purescript-ansi": "^1.0.0",
+    "purescript-node-path": "^1.0.0",
+    "purescript-control": "^1.0.0",
+    "purescript-console": "^1.0.0",
+    "purescript-unsafe-coerce": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "~1.0.0"
+    "purescript-psci-support": "^1.0.0"
   }
 }


### PR DESCRIPTION
This is creating version conflicts in `pscid` because `purescript-arrays: "~1.0.0"` doesn't resolve to "1.1.0".
