### PR TITLE
Upgrade argonaut dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "purescript-prelude": "^4.0.0",
     "purescript-effect": "^2.0.0",
     "purescript-argonaut-core": "^5.0.0",
-    "purescript-argonaut-codecs": "^6.0.2",
+    "purescript-argonaut-codecs": "^7.0.0",
     "purescript-maybe": "^4.0.0",
     "purescript-tuples": "^5.0.0",
     "purescript-arrays": "^5.0.0",

--- a/src/Psa/Types.purs
+++ b/src/Psa/Types.purs
@@ -168,7 +168,7 @@ parseSuggestion =
   maybe (pure Nothing) \obj -> map Just $
     { replacement: _
     , replaceRange: _
-    } <$> (obj .: "replacement")
+    } <$> obj .: "replacement"
       <*> (obj .:? "replaceRange" >>= parsePosition)
 
 encodePsaResult :: PsaResult -> Json


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors. This PR updates this library for compatibility.

I reviewed libraries that depend on psa-utils and noticed that they don't themselves use Argonaut, and so I thought it would be better to preserve the existing API with string errors so those libraries are unaffected instead of using `JsonDecodeError` in this library. However, if you think it would be better to use typed errors in this library's API and update these libraries downstream then I'm open to doing that also.

The libraries I checked:

* https://github.com/nwolverson/atom-ide-purescript/blob/master/bower.json
* https://github.com/nwolverson/purescript-suggest/blob/master/bower.json
* https://github.com/natefaubion/purescript-psa/blob/master/bower.json

If everything looks good, would you mind making a new release with the updated code so it's compatible with the upcoming package set? That'll ensure this package stays in the set.

Sorry for the hassle! Thanks!