### PR TITLE
Add support for finer grained censoring of user defined warnings

### DIFF
--- a/src/Psa/Types.purs
+++ b/src/Psa/Types.purs
@@ -69,6 +69,7 @@ instance ordPsaPath :: Ord PsaPath where
 type PsaOptions =
   { ansi :: Boolean
   , censorWarnings :: Boolean
+  , censorUserDefinedWarnings :: Set String
   , censorLib :: Boolean
   , censorSrc :: Boolean
   , censorCodes :: Set ErrorCode


### PR DESCRIPTION
This pull request allows one to censor specific Warn constraints, which is necessary if we want to use such constraints to deprecate stuff in core libraries.