### PR TITLE
Support allSpans in error json

### DIFF
--- a/test/Main.js
+++ b/test/Main.js
@@ -1,0 +1,5 @@
+export const assert = (s) => (condition) => () => {
+  if (!condition) {
+    throw new Error(s);
+  }
+}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,42 @@
+module Test.Main where
+
+import Prelude
+
+import Data.Argonaut.Core (stringify)
+import Data.Argonaut.Decode (decodeJson, printJsonDecodeError)
+import Data.Argonaut.Parser (jsonParser)
+import Data.Bifunctor (lmap)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Psa (PsaResult, encodePsaResult, parsePsaResult)
+
+foreign import assert :: String -> Boolean -> Effect Unit
+
+main :: Effect Unit
+main = do
+  let
+    -- Literal compiler output
+    output = """{"warnings":[],"errors":[{"position":{"startLine":5,"startColumn":9,"endLine":5,"endColumn":15},"message":"  Unknown type Effect\n","errorCode":"UnknownName","errorLink":"https://github.com/purescript/documentation/blob/master/errors/UnknownName.md","filename":"test/Main.purs","moduleName":"Test.Main","suggestion":null,"allSpans":[{"end":[5,15],"name":"test/Main.purs","start":[5,9]}]}]}"""
+    parse s = jsonParser s >>= (lmap printJsonDecodeError <<< decodeJson) >>= parsePsaResult
+
+    -- Manually mangled from output json
+    result :: PsaResult
+    result =
+      { warnings: []
+      , errors:
+          [ { position: Just { startLine: 5, startColumn: 9, endLine: 5, endColumn: 15 }
+            , message: "  Unknown type Effect\n"
+            , errorCode: "UnknownName"
+            , errorLink: "https://github.com/purescript/documentation/blob/master/errors/UnknownName.md"
+            , filename: Just "test/Main.purs"
+            , moduleName: Just "Test.Main"
+            , suggestion: Nothing
+            , allSpans: [ { start: { line: 5, column: 9 }, end: { line: 5, column: 15 }, name: "test/Main.purs" } ]
+            }
+          ]
+      }
+
+  assert "Parse simple error" $ parse output == Right result
+
+  assert "Round trips" $ Right result == (parse $ stringify $ encodePsaResult result)


### PR DESCRIPTION
`psa` currently drops `allSpans` from the compiler error JSON output, when passing through with `--json-errors`.

That has been in the compiler's JSON error/warning format for some time https://github.com/purescript/purescript/pull/3255 but I only recently realised this, and I'm adding support in the language server. I had some confusing results because in some testing, `psa` was dropping this field, when I didn't even realise `psa` was being picked up.